### PR TITLE
Bump oldest power_assert for the requirements

### DIFF
--- a/gemfiles/oldest.gemfile
+++ b/gemfiles/oldest.gemfile
@@ -22,7 +22,7 @@ end
 
 group :test do
   gem 'rspec', '3.5.0'
-  gem 'power_assert', '2.0.0'
+  gem 'power_assert', '2.0.3'
   gem 'irb', '1.4.0'
   gem 'warning', '~> 1.3.0'
 end

--- a/rspec-matchers-power_assert_matchers.gemspec
+++ b/rspec-matchers-power_assert_matchers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_runtime_dependency('rspec', '>= 3.5.0', '< 4.0')
-  gem.add_runtime_dependency('power_assert', '>= 2.0.0', '< 3.0')
+  gem.add_runtime_dependency('power_assert', '>= 2.0.3', '< 3.0')
   gem.add_runtime_dependency('irb', '>= 1.4.0', '< 2.0') # To colorize
 
   gem.required_ruby_version = '>= 2.7.2'


### PR DESCRIPTION
I found CI error with ruby-head oldest gems in https://github.com/kachick/rspec-matchers-power_assert_matchers/pull/69 as https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995

```
can not use rubocop in this environment
/home/runner/.rubies/ruby-head/bin/ruby -w -I/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib:/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-support-3.5.0/lib /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/power_assert-2.0.0/lib/power_assert.rb:17:in `rescue in <top (required)>': Fully compatible TracePoint API required (LoadError)
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/power_assert-2.0.0/lib/power_assert.rb:5:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/lib/rspec/matchers/power_assert_matchers.rb:6:in `require'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/lib/rspec/matchers/power_assert_matchers.rb:6:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/spec/spec_helper.rb:43:in `require_relative'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/spec/spec_helper.rb:43:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `require'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `block in requires='
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `each'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `requires='
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `each'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:21:in `configure'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:99:in `setup'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:[8](https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995#step:4:9)6:in `run'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/power_assert-2.0.0/lib/power_assert.rb:11:in `block in <top (required)>': unhandled exception
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/power_assert-2.0.0/lib/power_assert.rb:13:in `block in <top (required)>'
	from <internal:trace_point>:262:in `enable'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/power_assert-2.0.0/lib/power_assert.rb:13:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/lib/rspec/matchers/power_assert_matchers.rb:6:in `require'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/lib/rspec/matchers/power_assert_matchers.rb:6:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/spec/spec_helper.rb:43:in `require_relative'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/spec/spec_helper.rb:43:in `<top (required)>'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:13[9](https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995#step:4:10)4:in `require'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `block in requires='
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `each'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `requires='
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:[11](https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995#step:4:12)2:in `block in process_options_into'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `each'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:[21](https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995#step:4:22):in `configure'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:99:in `setup'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:[45](https://github.com/kachick/rspec-matchers-power_assert_matchers/actions/runs/3761747739/jobs/6393792995#step:4:46):in `invoke'
	from /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
/home/runner/.rubies/ruby-head/bin/ruby -w -I/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/lib:/home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-support-3.5.0/lib /home/runner/work/rspec-matchers-power_assert_matchers/rspec-matchers-power_assert_matchers/vendor/bundle/ruby/3.2.0+3/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
Error: Process completed with exit code 1.
```

Looks related to below

https://github.com/ruby/ruby/pull/6984
https://github.com/ruby/power_assert/pull/42
https://github.com/ruby/power_assert/commit/f309aea52defb10c108217f7e5c081763a837172
