### PR TITLE
Bump rspec-core to apply dropping ostruct commit for Ruby 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,5 @@ end
 
 group :test do
   gem 'rspec', '~> 3.13.0'
-  gem 'rspec-core', '~> 3.13.2'
   gem 'warning', '~> 1.5.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,10 @@ end
 
 group :test do
   gem 'rspec', '~> 3.13.0'
+  # Required to drop ostruct for ruby 3.5 or later.
+  # See below commits
+  #   - https://github.com/rspec/rspec/commit/07a5612bf96427e24e50a6e975a71784d340dd2b
+  #   - https://github.com/rspec/rspec/commit/3fc400f466e30d1df19688df6164bf2b5937f570
+  gem 'rspec-core', '~> 3.13.2'
   gem 'warning', '~> 1.5.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,6 @@ end
 
 group :test do
   gem 'rspec', '~> 3.13.0'
-  # Required to drop ostruct for ruby 3.5 or later.
-  # See below commits
-  #   - https://github.com/rspec/rspec/commit/07a5612bf96427e24e50a6e975a71784d340dd2b
-  #   - https://github.com/rspec/rspec/commit/3fc400f466e30d1df19688df6164bf2b5937f570
   gem 'rspec-core', '~> 3.13.2'
   gem 'warning', '~> 1.5.0'
 end

--- a/gemfiles/oldest.gemfile
+++ b/gemfiles/oldest.gemfile
@@ -21,7 +21,12 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '3.5.0'
+  gem 'rspec', '3.13.0'
+  # Required to drop ostruct for ruby 3.5 or later.
+  # See below commits
+  #   - https://github.com/rspec/rspec/commit/07a5612bf96427e24e50a6e975a71784d340dd2b
+  #   - https://github.com/rspec/rspec/commit/3fc400f466e30d1df19688df6164bf2b5937f570
+  gem 'rspec-core', '3.13.2'
   gem 'power_assert', '2.0.3'
   gem 'irb', '1.4.0'
   gem 'warning', '~> 1.3.0'

--- a/gemfiles/oldest.gemfile
+++ b/gemfiles/oldest.gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 gemspec(path: Pathname(__dir__).parent)
 
 group :development, :test do
-  gem 'rake', '~> 13.0.6'
+  gem 'rake', '~> 13.2.1'
 end
 
 group :development do


### PR DESCRIPTION
This is the cause of failing CI in GH-266
